### PR TITLE
build: poppler 23.06.0

### DIFF
--- a/builder.Dockerfile
+++ b/builder.Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:2018.03
+FROM amazonlinux:2
 
 ENV SOURCE_DIR="/opt"
 ENV INSTALL_DIR="/opt"


### PR DESCRIPTION
- Build Poppler 23.06.0
- Add Boost
- Add GObject Introspection
- Update Amazon Linux to 2
- Update dependencies to current versions
